### PR TITLE
Fixes a bug were the fields don't rematch when making a PUT request to update

### DIFF
--- a/code/model/ApiDataObject.php
+++ b/code/model/ApiDataObject.php
@@ -118,7 +118,7 @@ class ApiDataObject extends DataExtension {
     if (preg_match("/\_id$/", $field)) {
       return $field = ApiDataObject::to_camelcase($field, $checkID = true);
     } else if (preg_match("/^[a-z\_0-9]+$/", $field)) {
-      foreach($ownerClass->inheritedApiFields() as $fieldName => $type) {
+      foreach($ownerClass->inheritedApiFields() as $fieldName) {
         if (strtolower($fieldName)===$fieldnameWithoutUnderscore)
           return $fieldName;
       }


### PR DESCRIPTION
I’ve just noticed this bug were the array iterator was used instead of the array value. I’m guessing that Silverstripe has changed what the expected output is
